### PR TITLE
Fix for non-iOS5 only ARC projects

### DIFF
--- a/Twitter+OAuth/MGTwitterEngine/MGTwitterEngine.h
+++ b/Twitter+OAuth/MGTwitterEngine/MGTwitterEngine.h
@@ -12,7 +12,7 @@
 #import "MGTwitterParserDelegate.h"
 
 @interface MGTwitterEngine : NSObject <MGTwitterParserDelegate> {
-    __weak NSObject <MGTwitterEngineDelegate> *_delegate;
+    __unsafe_unretained NSObject <MGTwitterEngineDelegate> *_delegate;
     NSString *_username;
     NSString *_password;
     NSMutableDictionary *_connections;   // MGTwitterHTTPURLConnection objects


### PR DESCRIPTION
No, this doesn't make the library ARC compatible.

What I have done, I changed a __weak to __unsafe_unretained.

__weak is supported in ARC in iOS5+ only (http://blog.mugunthkumar.com/articles/migrating-your-code-to-objective-c-arc/). The fallback is __unsafe_unretained

With this modification, people can still use this project in a ARC project, where all .m files use the --fno-objc-arc flag, without it, this library is completely useless as-is in any ARC project that support 4.0+
