### PR TITLE
Bug fix for 'No, thanks' button

### DIFF
--- a/Twitter+OAuth/SAOAuthTwitterEngine/SA_OAuthTwitterController.m
+++ b/Twitter+OAuth/SAOAuthTwitterEngine/SA_OAuthTwitterController.m
@@ -341,7 +341,7 @@ Ugly. I apologize for its inelegance. Bleah.
 	NSData				*data = [request HTTPBody];
 	char				*raw = data ? (char *) [data bytes] : "";
 	
-	if (raw && strstr(raw, "cancel=")) {
+	if (raw && (strstr(raw, "cancel=") || strstr(raw, "deny="))) {
 		[self denied];
 		return NO;
 	}


### PR DESCRIPTION
Problem: button 'No, thanks' in Twitter authorization view didn't work (method '- (void) denied' didn't call).
Cause: parameter 'cancel' in request body was renamed to 'deny'.

I was added 'deny' parameter (and save parameter 'cancel' for same reasons). Now this button is working correct.
