### PR TITLE
Fix memory leak in MGTwitterLibXMLParser.

### DIFF
--- a/Twitter+OAuth/MGTwitterEngine/MGTwitterLibXMLParser.m
+++ b/Twitter+OAuth/MGTwitterEngine/MGTwitterLibXMLParser.m
@@ -50,6 +50,7 @@ connectionIdentifier:(NSString *)theIdentifier requestType:(MGTwitterRequestType
 		_reader = xmlReaderForMemory([xml bytes], [xml length], [[URL absoluteString] UTF8String], nil, XML_PARSE_NOBLANKS | XML_PARSE_NOCDATA | XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 		if (! _reader)
 		{
+			[self release];
 			return nil;
 		}
 


### PR DESCRIPTION
In case xmlReaderForMemory() fails, nil is returned from the initWithXML method, so the alloc should be reverted.
