### PR TITLE
Added oauth_callback=oob to the request as request gets redirected to callback url set in the twitter app instead of returning the pin.

### DIFF
--- a/Twitter+OAuth/SAOAuthTwitterEngine/SA_OAuthTwitterEngine.m
+++ b/Twitter+OAuth/SAOAuthTwitterEngine/SA_OAuthTwitterEngine.m
@@ -150,6 +150,15 @@
 	
 	if (self.pin.length) token.pin = self.pin;
     [request setHTTPMethod: @"POST"];
+    
+    /*
+     Added oauth_callback param to the request, which is required for OOB (out-of-band) authentication, without which 
+     twitter does not return a pin but redirects to the callback url set in the app on twitter.com, hence failing the authentication.
+     https://dev.twitter.com/docs/auth/pin-based-authorization
+    */
+	NSMutableArray *params =  [[NSMutableArray alloc] initWithArray:request.parameters];
+	[params addObject:[[OARequestParameter alloc] initWithName:@"oauth_callback" value:@"oob"]];
+	request.parameters = params;
 	
     OADataFetcher				*fetcher = [[[OADataFetcher alloc] init] autorelease];	
     [fetcher fetchDataWithRequest: request delegate: self didFinishSelector: success didFailSelector: fail];


### PR DESCRIPTION
...t-of-band) authentication

Without oauth_callback param twitter does not return a pin but
redirects to the callback url set in the app on twitter.com, hence
failing the authentication. More at:
https://dev.twitter.com/docs/auth/pin-based-authorization
